### PR TITLE
Updated README to show correct usage of Set command

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ To set a value you must open a read/write transaction:
 
 ```go
 err := db.Update(func(tx *flashdb.Tx) error {
-	_, _, err := tx.Set("mykey", "myvalue")
+	err := tx.Set("mykey", "myvalue")
 	return err
 })
 ```


### PR DESCRIPTION
**Issue**
`Set` API doesn't returns 3 values as mentioned in the documentation. It just returns an `error` instance.

```
func (tx *Tx) Set(key string, value string) error {
	e := newRecord([]byte(key), []byte(value), StringRecord, StringSet)
	tx.addRecord(e)

	return nil
}
```

**Changes**
Updating the documentation to reflect the correct usage of `Set` API